### PR TITLE
Some Table redesign

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -7,8 +7,12 @@ h1, h2, h3, h4, h5 {
   vertical-align: middle;
 }
 
+thead tr {
+  line-height: 1;
+}
+
 tbody tr {
-  height: 64px;
+  height: 74px;
 }
 
 /* sets width of title/name column */
@@ -182,8 +186,9 @@ th:nth-of-type(2) {
 }
 
 .table-icon-wide {
-  height: 2rem;
-  margin-right: 0;
+  width: 64px;
+  height: 32px;
+  margin-right: 12px;
   cursor: pointer;
 }
 
@@ -200,6 +205,7 @@ th:nth-of-type(2) {
   width: 28px;
   border-radius: 50%;
   margin: 8px;
+  cursor: pointer;
 }
 
 .editing-row .form-control {

--- a/css/main.css
+++ b/css/main.css
@@ -4,6 +4,9 @@ h1, h2, h3, h4, h5 {
 
 .container {
   color: #555;
+  /*max-width: none;*/
+  /*padding: 0 8%;*/
+  max-width: 1180px;
 }
 
 .header {
@@ -117,7 +120,7 @@ tbody tr {
 
 /* sets width of title/name column */
 th:nth-of-type(2) {
-  width: 220px;
+  width: 270px;
 }
 
 /* sets width of input form for date and point editing */

--- a/css/main.css
+++ b/css/main.css
@@ -2,24 +2,6 @@ h1, h2, h3, h4, h5 {
   font-weight: normal;
 }
 
-.table td, .table th {
-  padding: .75rem .5rem;
-  vertical-align: middle;
-}
-
-thead tr {
-  line-height: 1;
-}
-
-tbody tr {
-  height: 74px;
-}
-
-/* sets width of title/name column */
-th:nth-of-type(2) {
-  width: 270px;
-}
-
 .container {
   color: #555;
 }
@@ -118,6 +100,29 @@ th:nth-of-type(2) {
 
 .table {
   margin-bottom: 0;
+}
+
+.table td, .table th {
+  padding: .75rem .5rem;
+  vertical-align: middle;
+}
+
+thead tr {
+  line-height: 1;
+}
+
+tbody tr {
+  height: 74px;
+}
+
+/* sets width of title/name column */
+th:nth-of-type(2) {
+  width: 220px;
+}
+
+/* sets width of input form for date and point editing */
+input.form-control {
+  width: 170px;
 }
 
 .preview {

--- a/css/main.css
+++ b/css/main.css
@@ -125,6 +125,10 @@ input.form-control {
   width: 170px;
 }
 
+.challenge-title {
+  cursor: pointer;
+}
+
 .preview {
   position: absolute;
   right: 15px;

--- a/css/main.css
+++ b/css/main.css
@@ -7,8 +7,13 @@ h1, h2, h3, h4, h5 {
   vertical-align: middle;
 }
 
+tbody tr {
+  height: 64px;
+}
+
+/* sets width of title/name column */
 th:nth-of-type(2) {
-  width: 340px;
+  width: 270px;
 }
 
 .container {
@@ -93,6 +98,11 @@ th:nth-of-type(2) {
   color: inherit;
 }
 
+.card-header {
+  background-color: rgba(0, 0, 0, .02);
+  border-bottom: none;
+}
+
 .card-body {
   padding: 0;
 }
@@ -124,6 +134,7 @@ th:nth-of-type(2) {
 
 .oi-caret-bottom {
   float: right;
+  top: 3px;
 }
 
 .home-button {
@@ -168,9 +179,8 @@ th:nth-of-type(2) {
 }
 
 .table-icon-wide {
-  width: 48px;
-  height: 24px;
-  margin-right: 12px;
+  height: 2rem;
+  margin-right: 0;
 }
 
 .add-targeting-button, .add-resource-button {

--- a/css/main.css
+++ b/css/main.css
@@ -157,14 +157,17 @@ th:nth-of-type(2) {
   margin-right: 20%;
 }
 
+.preview-icon,
 .delete-icon {
   width: 24px;
+  cursor: pointer;
 }
 
 .add-icon {
   width: 32px;
   border-radius: 50%;
   background-color: #d92c27;
+  cursor: pointer;
 }
 
 .calendar-link {
@@ -181,6 +184,7 @@ th:nth-of-type(2) {
 .table-icon-wide {
   height: 2rem;
   margin-right: 0;
+  cursor: pointer;
 }
 
 .add-targeting-button, .add-resource-button {

--- a/src/components/accordion_card.jsx
+++ b/src/components/accordion_card.jsx
@@ -271,17 +271,25 @@ class AccordionCard extends Component {
     const formattedEndDate = endDate ? moment(endDate).format('L') : '';
 
     return (
-      <div className="card">
+      <section className="card">
 
-        <div className="card-header" role="tab" id={'header' + id}>
-          <h5 className="mb-0">
-            <a data-toggle="collapse" href={'#collapse' + id}>
-              <span>{title}</span>
-              <span className="left-15">{formattedStartDate} - {formattedEndDate}</span>
-              <span className="left-abs-73">{totalPoints} Points</span>
-              <span className="oi oi-caret-bottom"></span>
-            </a>
-          </h5>
+        <div className="card-header" role="tab" id={'header' + id}>       
+          <div className="mb-0 row">
+            <div className="col-md-3">
+              <h5 id={'title' + id}>{title}</h5>
+            </div>
+            <div className="col-md-5">
+              <h5 id={'dates' + id}>{formattedStartDate} - {formattedEndDate}</h5>
+            </div>
+            <div className="col-md-3">
+              <h5 id={'points' + id}>{totalPoints} Points</h5>
+            </div>
+            <div className="col-md-1">
+              <a data-toggle="collapse" href={'#collapse' + id}>
+                <h5 className="oi oi-caret-bottom"></h5>
+              </a>
+            </div>
+          </div>
         </div>
 
         <div id={'collapse' + id} className="collapse show" role="tabpanel">
@@ -319,7 +327,7 @@ class AccordionCard extends Component {
           </div>
         </div>
 
-      </div>
+      </section>
     );
   }
 }

--- a/src/components/accordion_card.jsx
+++ b/src/components/accordion_card.jsx
@@ -275,10 +275,10 @@ class AccordionCard extends Component {
 
         <div className="card-header" role="tab" id={'header' + id}>       
           <div className="mb-0 row">
-            <div className="col-md-3">
+            <div className="col-md-4">
               <h5 id={'title' + id}>{title}</h5>
             </div>
-            <div className="col-md-5">
+            <div className="col-md-4">
               <h5 id={'dates' + id}>{formattedStartDate} - {formattedEndDate}</h5>
             </div>
             <div className="col-md-3">

--- a/src/components/accordion_card.jsx
+++ b/src/components/accordion_card.jsx
@@ -199,7 +199,7 @@ class AccordionCard extends Component {
         <td>
           <img className="table-icon-wide" src={challenge.fields['Header Image']} onClick={() => this.editChallenge(challenge)} />
         </td>
-        <td scope="row">{challenge.fields['Title']}</td>
+        <td scope="row"><span className="challenge-title" onClick={() => this.editChallenge(challenge)}>{challenge.fields['Title']}</span></td>
         <td>{challenge.fields['Verified']}</td>
         <td className="text-center">
           <img className="table-icon category-icon" src={this.hpImage(challenge.fields['Category'])} />

--- a/src/components/accordion_card.jsx
+++ b/src/components/accordion_card.jsx
@@ -202,16 +202,16 @@ class AccordionCard extends Component {
         <td scope="row">{challenge.fields['Title']}</td>
         <td>{challenge.fields['Verified']}</td>
         <td className="text-center">
-          <img className="table-icon" src={this.hpImage(challenge.fields['Category'])} />
-          <img className="table-icon" src={this.teamImage(challenge.fields['Team Activity'])} />
+          <img className="table-icon category-icon" src={this.hpImage(challenge.fields['Category'])} />
+          <img className="table-icon team-icon" src={this.teamImage(challenge.fields['Team Activity'])} />
         </td>
         <td onDoubleClick={(e) => this.editStartDate(e, challenge)}>{moment(startDate).format('L')}</td>
         <td onDoubleClick={(e) => this.editEndDate(e, challenge)}>{moment(endDate).format('L')}</td>
         <td>{challenge.fields['Reward Occurrence']}</td>
         <td onDoubleClick={(e) => this.editPoints(e, challenge)}>{challenge.fields['Points']} ({challenge.fields['Total Points']})</td>
         <td className="text-center">
-          <img className="table-icon" src={hasBeenEdited ? 'images/icon_preview_notification.svg' : 'images/icon_preview.svg'} onClick={() => this.editChallenge(challenge)} />
-          <img className="table-icon" src="images/icon_delete.svg" onClick={() => this.openDeleteConfirmModal(challenge)} />
+          <img className="table-icon preview-icon" src={hasBeenEdited ? 'images/icon_preview_notification.svg' : 'images/icon_preview.svg'} onClick={() => this.editChallenge(challenge)} />
+          <img className="table-icon delete-icon" src="images/icon_delete.svg" onClick={() => this.openDeleteConfirmModal(challenge)} />
         </td>
       </tr>
     );


### PR DESCRIPTION
* Slightly increased the max-width of the table, but kept it a fixed maximum so it doesn't look crazy on large monitors
* Increased the tbody tr height so editing dates and points doesn't push things around, also helps with titles that go on the second line
* Decreased the thead tr height so it has less emphasis than the data in the tbody
* Made the challenge image icon slightly larger (but not enough to where it would wreak the visual hierarchy)
* Made the challenge title field smaller, so it's not quite as ridiculous
* Added pointer icon on hover of actionable icons/objects
* Changed the accordion to only collapse when the caret is clicked, not the other row elements
* Added the preview onClick to the challenge title, but did not style it as a link so it doesn't have *too* much emphasis