### PR TITLE
"Fix" alert bug when invalid dates are entered

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -143,6 +143,16 @@ input.form-control {
   border-radius: 12px;
 }
 
+.start-date-validate {
+  color: red;
+  display: none;
+}
+
+.end-date-validate {
+  color: red;
+  display: none;
+}
+
 .preview {
   position: absolute;
   right: 15px;

--- a/css/main.css
+++ b/css/main.css
@@ -143,16 +143,6 @@ input.form-control {
   border-radius: 12px;
 }
 
-.start-date-validate {
-  color: red;
-  display: none;
-}
-
-.end-date-validate {
-  color: red;
-  display: none;
-}
-
 .preview {
   position: absolute;
   right: 15px;

--- a/src/components/challenge.jsx
+++ b/src/components/challenge.jsx
@@ -55,13 +55,11 @@ function Challenge({ challenge, index, openPreviewChallengeModal, updateChalleng
 
     // alert user if the end date is before the start date
     if (endDate.isBefore(startDate)) {
-      // alert('Error: The Start Date must be before the End Date.');
+      alert('Error: The Start Date must be before the End Date.');
       $('#editingStartDate').addClass('invalid');
-      $('.start-date-validate').show();
     } else {
       // do other actions because end date is valid
       $('#editingStartDate').removeClass('invalid');
-      $('.end-date-validate').hide();
       $('#editingStartDate').parent().html(`${moment(challenge.fields['Start date']).format('L')}`);
 
       challenge.fields['Start date'] = e.target.value;
@@ -92,14 +90,6 @@ function Challenge({ challenge, index, openPreviewChallengeModal, updateChalleng
     $('#editingStartDate').blur((ev) => {
       validateStartDate(ev, challenge);
     });
-
-    // When user hits enter, also change it back
-    $('#editingStartDate').on('keypress', (ev) => {
-      if (event.key === 'Enter') {
-        validateStartDate(ev, challenge);
-      }
-    });
-
   }
 
   function validateEndDate(e, challenge) {
@@ -108,13 +98,11 @@ function Challenge({ challenge, index, openPreviewChallengeModal, updateChalleng
 
     // alert user if the end date is before the start date
     if (endDate.isBefore(startDate)) {
-      // alert('Error: The Start Date must be before the End Date.');
+      alert('Error: The Start Date must be before the End Date.');
       $('#editingEndDate').addClass('invalid');
-      $('.end-date-validate').show();
     } else {
       // do other actions because end date is valid
       $('#editingEndDate').removeClass('invalid');
-      $('.end-date-validate').show();
       $('#editingEndDate').parent().html(`${moment(challenge.fields['End date']).format('L')}`);
 
       challenge.fields['End date'] = e.target.value;
@@ -144,13 +132,6 @@ function Challenge({ challenge, index, openPreviewChallengeModal, updateChalleng
     // When user clicks out of the input, change it back to the original readonly version with the updated data
     $('#editingEndDate').blur((ev) => {
       validateEndDate(ev, challenge);
-    });
-
-    // When user hits enter, also change it back
-    $('#editingEndDate').on('keypress', (ev) => {
-      if (event.key === 'Enter') {
-        validateEndDate(ev, challenge);
-      }
     });
   }
 
@@ -287,8 +268,8 @@ function Challenge({ challenge, index, openPreviewChallengeModal, updateChalleng
             <img className="table-icon category-icon" src={hpImage(challenge.fields['Category'])} title={(challenge.fields['Category'])} />
             <img className="table-icon team-icon" src={teamImage(challenge.fields['Team Activity'])} title={ isTeam ? 'Team' : 'Individual' } />
           </td>
-          <td title="Start date" onDoubleClick={(e) => editStartDate(e, challenge)}><span className="start-date">{moment(startDate).format('L')}</span><p className="start-date-validate">Error.</p></td>
-          <td title="End date" onDoubleClick={(e) => editEndDate(e, challenge)}><span className="end-date">{moment(endDate).format('L')}</span><p className="end-date-validate">Error.</p></td>
+          <td title="Start date" onDoubleClick={(e) => editStartDate(e, challenge)}><span className="start-date">{moment(startDate).format('L')}</span></td>
+          <td title="End date" onDoubleClick={(e) => editEndDate(e, challenge)}><span className="end-date">{moment(endDate).format('L')}</span></td>
           <td title="Reward Occurrence">{challenge.fields['Reward Occurrence']}</td>
           <td title="Points (Total Points)" onDoubleClick={(e) => editPoints(e, challenge)}><span className="points-text">{challenge.fields['Points']} ({challenge.fields['Total Points']})</span></td>
           <td className="actions text-center">

--- a/src/components/challenge.jsx
+++ b/src/components/challenge.jsx
@@ -55,11 +55,13 @@ function Challenge({ challenge, index, openPreviewChallengeModal, updateChalleng
 
     // alert user if the end date is before the start date
     if (endDate.isBefore(startDate)) {
-      alert('Error: The Start Date must be before the End Date.');
+      // alert('Error: The Start Date must be before the End Date.');
       $('#editingStartDate').addClass('invalid');
+      $('.start-date-validate').show();
     } else {
       // do other actions because end date is valid
       $('#editingStartDate').removeClass('invalid');
+      $('.end-date-validate').hide();
       $('#editingStartDate').parent().html(`${moment(challenge.fields['Start date']).format('L')}`);
 
       challenge.fields['Start date'] = e.target.value;
@@ -106,11 +108,13 @@ function Challenge({ challenge, index, openPreviewChallengeModal, updateChalleng
 
     // alert user if the end date is before the start date
     if (endDate.isBefore(startDate)) {
-      alert('Error: The Start Date must be before the End Date.');
+      // alert('Error: The Start Date must be before the End Date.');
       $('#editingEndDate').addClass('invalid');
+      $('.end-date-validate').show();
     } else {
       // do other actions because end date is valid
       $('#editingEndDate').removeClass('invalid');
+      $('.end-date-validate').show();
       $('#editingEndDate').parent().html(`${moment(challenge.fields['End date']).format('L')}`);
 
       challenge.fields['End date'] = e.target.value;
@@ -283,8 +287,8 @@ function Challenge({ challenge, index, openPreviewChallengeModal, updateChalleng
             <img className="table-icon category-icon" src={hpImage(challenge.fields['Category'])} title={(challenge.fields['Category'])} />
             <img className="table-icon team-icon" src={teamImage(challenge.fields['Team Activity'])} title={ isTeam ? 'Team' : 'Individual' } />
           </td>
-          <td title="Start date" onDoubleClick={(e) => editStartDate(e, challenge)}><span className="start-date">{moment(startDate).format('L')}</span></td>
-          <td title="End date" onDoubleClick={(e) => editEndDate(e, challenge)}><span className="end-date">{moment(endDate).format('L')}</span></td>
+          <td title="Start date" onDoubleClick={(e) => editStartDate(e, challenge)}><span className="start-date">{moment(startDate).format('L')}</span><p className="start-date-validate">Error.</p></td>
+          <td title="End date" onDoubleClick={(e) => editEndDate(e, challenge)}><span className="end-date">{moment(endDate).format('L')}</span><p className="end-date-validate">Error.</p></td>
           <td title="Reward Occurrence">{challenge.fields['Reward Occurrence']}</td>
           <td title="Points (Total Points)" onDoubleClick={(e) => editPoints(e, challenge)}><span className="points-text">{challenge.fields['Points']} ({challenge.fields['Total Points']})</span></td>
           <td className="actions text-center">


### PR DESCRIPTION
I was looking for a fancy way to fix this, but I ended up just removing the 'Enter' key functionality.

Besides, the Tab key counts as a blur() event, so that's good enough for me. And I think it's good enough for clients and AMs too.

![enter](https://user-images.githubusercontent.com/16523445/60307642-52359500-98fa-11e9-9228-53d1327964af.jpg)

Anyway, this is a half-measure, and if you want to reject the PR, I won't be hurt.